### PR TITLE
Convert timestamp to datetime.datetime object

### DIFF
--- a/osrparse/replay.py
+++ b/osrparse/replay.py
@@ -123,7 +123,8 @@ class Replay(object):
 
     def parse_timestamp_and_replay_length(self, replay_data):
         format_specifier = "<qi"
-        (self.timestamp, self.__replay_length) = struct.unpack_from(format_specifier, replay_data, self.offset)
+        (t, self.__replay_length) = struct.unpack_from(format_specifier, replay_data, self.offset)
+        self.timestamp = datetime.datetime(1, 1, 1) + datetime.timedelta(microseconds=t/10)
         self.offset += struct.calcsize(format_specifier)
 
     def parse_play_data(self, replay_data):

--- a/osrparse/replay.py
+++ b/osrparse/replay.py
@@ -1,5 +1,5 @@
 from .enums import GameMode, Mod
-import lzma, struct
+import lzma, struct, datetime
 
 
 class ReplayEvent(object):

--- a/osrparse/replay.py
+++ b/osrparse/replay.py
@@ -124,7 +124,7 @@ class Replay(object):
     def parse_timestamp_and_replay_length(self, replay_data):
         format_specifier = "<qi"
         (t, self.__replay_length) = struct.unpack_from(format_specifier, replay_data, self.offset)
-        self.timestamp = datetime.datetime(1, 1, 1) + datetime.timedelta(microseconds=t/10)
+        self.timestamp = datetime.datetime.min + datetime.timedelta(microseconds=t/10)
         self.offset += struct.calcsize(format_specifier)
 
     def parse_play_data(self, replay_data):

--- a/tests/replay_test.py
+++ b/tests/replay_test.py
@@ -54,7 +54,7 @@ class TestStandardReplay(unittest.TestCase):
 
     def test_timestamp(self):
         for replay in self._replays:
-            self.assertEqual(replay.timestamp, 634953330940000000, "Timestamp is wrong")
+            self.assertEqual(replay.timestamp, datetime.datetime(2013, 2, 1, 16, 31, 34), "Timestamp is wrong")
 
     def test_play_data(self):
         for replay in self._replays:

--- a/tests/replay_test.py
+++ b/tests/replay_test.py
@@ -1,4 +1,4 @@
-import unittest
+import unittest, datetime
 from osrparse.replay import parse_replay, parse_replay_file, ReplayEvent
 from osrparse.enums import GameMode, Mod
 


### PR DESCRIPTION
Changed timestamp attribute to be a datetime.datetime instead of simply an int of windows ticks