### PR TITLE
Allow play_data for Catch, Taiko & Mania

### DIFF
--- a/osrparse/parse.py
+++ b/osrparse/parse.py
@@ -3,8 +3,7 @@ from typing import Union
 
 from osrparse.replay import Replay
 
-def parse_replay(replay_data: str, pure_lzma: bool = False, decompressed_lzma: bool = False,
-                 allow_unsupported_play_data: bool = False) -> Replay:
+def parse_replay(replay_data: str, pure_lzma: bool = False, decompressed_lzma: bool = False) -> Replay:
     """
     Parses a Replay from the given replay data.
 
@@ -28,16 +27,14 @@ def parse_replay(replay_data: str, pure_lzma: bool = False, decompressed_lzma: b
                 >>> osrparse.parse_replay(lzma_string, pure_lzma=True, decompressed_lzma=True)
                 ```
                 This parameter only has an affect if ``pure_lzma`` is ``True``.
-        Boolean allow_unsupported_play_data: Whether to allow non-Standard Modes to parse data.
     Returns:
         A Replay object with the fields specific in the Replay's init method. If pure_lzma is False, all fields will
         be filled (nonnull). If pure_lzma is True, only the play_data will be filled.
     """
 
-    return Replay(replay_data, pure_lzma, decompressed_lzma, allow_unsupported_play_data)
+    return Replay(replay_data, pure_lzma, decompressed_lzma)
 
-def parse_replay_file(replay_path: Union[os.PathLike, str], pure_lzma: bool = False,
-                      allow_unsupported_play_data: bool = False) -> Replay:
+def parse_replay_file(replay_path: Union[os.PathLike, str], pure_lzma: bool = False) -> Replay:
     """
     Parses a Replay from the file at the given path.
 
@@ -47,9 +44,8 @@ def parse_replay_file(replay_path: Union[os.PathLike, str], pure_lzma: bool = Fa
                            and True if the file contains only lzma data. See parse_replay documentation for
                            more information on the difference between these two and how each affect the
                            fields in the final Replay object.
-        Boolean allow_unsupported_play_data: Whether to allow non-Standard Modes to parse data.
     """
 
     with open(replay_path, 'rb') as f:
         data = f.read()
-    return parse_replay(data, pure_lzma, allow_unsupported_play_data=allow_unsupported_play_data)
+    return parse_replay(data, pure_lzma)

--- a/osrparse/parse.py
+++ b/osrparse/parse.py
@@ -3,7 +3,8 @@ from typing import Union
 
 from osrparse.replay import Replay
 
-def parse_replay(replay_data: str, pure_lzma: bool = False, decompressed_lzma: bool = False) -> Replay:
+def parse_replay(replay_data: str, pure_lzma: bool = False, decompressed_lzma: bool = False,
+                 allow_unsupported_play_data: bool = False) -> Replay:
     """
     Parses a Replay from the given replay data.
 
@@ -27,14 +28,16 @@ def parse_replay(replay_data: str, pure_lzma: bool = False, decompressed_lzma: b
                 >>> osrparse.parse_replay(lzma_string, pure_lzma=True, decompressed_lzma=True)
                 ```
                 This parameter only has an affect if ``pure_lzma`` is ``True``.
+        Boolean allow_unsupported_play_data: Whether to allow non-Standard Modes to parse data.
     Returns:
         A Replay object with the fields specific in the Replay's init method. If pure_lzma is False, all fields will
         be filled (nonnull). If pure_lzma is True, only the play_data will be filled.
     """
 
-    return Replay(replay_data, pure_lzma, decompressed_lzma)
+    return Replay(replay_data, pure_lzma, decompressed_lzma, allow_unsupported_play_data)
 
-def parse_replay_file(replay_path: Union[os.PathLike, str], pure_lzma: bool = False) -> Replay:
+def parse_replay_file(replay_path: Union[os.PathLike, str], pure_lzma: bool = False,
+                      allow_unsupported_play_data: bool = False) -> Replay:
     """
     Parses a Replay from the file at the given path.
 
@@ -44,8 +47,9 @@ def parse_replay_file(replay_path: Union[os.PathLike, str], pure_lzma: bool = Fa
                            and True if the file contains only lzma data. See parse_replay documentation for
                            more information on the difference between these two and how each affect the
                            fields in the final Replay object.
+        Boolean allow_unsupported_play_data: Whether to allow non-Standard Modes to parse data.
     """
 
     with open(replay_path, 'rb') as f:
         data = f.read()
-    return parse_replay(data, pure_lzma)
+    return parse_replay(data, pure_lzma, allow_unsupported_play_data=allow_unsupported_play_data)

--- a/osrparse/replay.py
+++ b/osrparse/replay.py
@@ -32,8 +32,7 @@ class Replay():
     _INT = 4
     _LONG = 8
 
-    def __init__(self, replay_data: List[ReplayEvent], pure_lzma: bool, decompressed_lzma: bool,
-                 allow_unsupported_play_data: bool = False):
+    def __init__(self, replay_data: List[ReplayEvent], pure_lzma: bool, decompressed_lzma: bool):
         self.offset = 0
         self.game_mode = None
         self.game_version = None
@@ -54,7 +53,6 @@ class Replay():
         self.timestamp = None
         self.play_data = None
         self.replay_id = None
-        self._allow_unsupported_play_data = allow_unsupported_play_data
         self._parse_replay_and_initialize_fields(replay_data, pure_lzma, decompressed_lzma)
 
     def _parse_replay_and_initialize_fields(self, replay_data, pure_lzma, decompressed_lzma):
@@ -136,12 +134,11 @@ class Replay():
 
     def _parse_play_data(self, replay_data):
         offset_end = self.offset+self.replay_length
-        if self.game_mode == GameMode.STD or self._allow_unsupported_play_data:
-            datastring = lzma.decompress(replay_data[self.offset:offset_end], format=lzma.FORMAT_AUTO).decode('ascii')[:-1]
-            events = [eventstring.split('|') for eventstring in datastring.split(',')]
-            self.play_data = [ReplayEvent(int(event[0]), float(event[1]), float(event[2]), int(event[3])) for event in events]
-        else:
-            self.play_data = None
+
+        datastring = lzma.decompress(replay_data[self.offset:offset_end], format=lzma.FORMAT_AUTO).decode('ascii')[:-1]
+        events = [eventstring.split('|') for eventstring in datastring.split(',')]
+        self.play_data = [ReplayEvent(int(event[0]), float(event[1]), float(event[2]), int(event[3])) for event in events]
+
         self.offset = offset_end
 
         if self.game_version >= self.LAST_FRAME_SEED_VERSION and self.play_data:

--- a/osrparse/replay.py
+++ b/osrparse/replay.py
@@ -32,7 +32,8 @@ class Replay():
     _INT = 4
     _LONG = 8
 
-    def __init__(self, replay_data: List[ReplayEvent], pure_lzma: bool, decompressed_lzma: bool):
+    def __init__(self, replay_data: List[ReplayEvent], pure_lzma: bool, decompressed_lzma: bool,
+                 allow_unsupported_play_data: bool = False):
         self.offset = 0
         self.game_mode = None
         self.game_version = None
@@ -53,6 +54,7 @@ class Replay():
         self.timestamp = None
         self.play_data = None
         self.replay_id = None
+        self._allow_unsupported_play_data = allow_unsupported_play_data
         self._parse_replay_and_initialize_fields(replay_data, pure_lzma, decompressed_lzma)
 
     def _parse_replay_and_initialize_fields(self, replay_data, pure_lzma, decompressed_lzma):
@@ -134,12 +136,12 @@ class Replay():
 
     def _parse_play_data(self, replay_data):
         offset_end = self.offset+self.replay_length
-        if self.game_mode != GameMode.STD:
-            self.play_data = None
-        else:
+        if self.game_mode == GameMode.STD or self._allow_unsupported_play_data:
             datastring = lzma.decompress(replay_data[self.offset:offset_end], format=lzma.FORMAT_AUTO).decode('ascii')[:-1]
             events = [eventstring.split('|') for eventstring in datastring.split(',')]
             self.play_data = [ReplayEvent(int(event[0]), float(event[1]), float(event[2]), int(event[3])) for event in events]
+        else:
+            self.play_data = None
         self.offset = offset_end
 
         if self.game_version >= self.LAST_FRAME_SEED_VERSION and self.play_data:


### PR DESCRIPTION
closes #16, closes #23

I found this library very useful, however, I'm working on parsing ``play_data`` on mania, which is a problem.
Though it's not explicitly supported, it works fine.

Image shows mania replay being loaded.
![image](https://user-images.githubusercontent.com/26498608/119085311-1a77ef00-ba36-11eb-86cd-b5b05e423463.png)

# Changes

## Add ``allow_unsupported_play_data`` argument

This, by default is ``False``. 

It's set in the ``__init__`` here 
``self._allow_unsupported_play_data = allow_unsupported_play_data``

The argument simply propogates down to ``_parse_play_data`` as a property.

I adjusted the conditional a bit to make it clearer.
```py
if self.game_mode == GameMode.STD or self._allow_unsupported_play_data:
    datastring = ...
else:
    self.play_data = None
```

## Add Documentation

Hopefully I formatted it right,

```
...
Boolean allow_unsupported_play_data: Whether to allow non-Standard Modes to parse data.
...
```

## Testing

I attached a replay for you to test it.
[Evening - Yunomi feat. nicamoq - Robotic Girl (Srav3R Remix) [Unscathed Heart] (2021-05-15) OsuMania.zip](https://github.com/kszlim/osu-replay-parser/files/6520260/Evening.-.Yunomi.feat.nicamoq.-.Robotic.Girl.Srav3R.Remix.Unscathed.Heart.2021-05-15.OsuMania.zip)

```py
from osrparse import parse_replay_file, ReplayEvent

a = parse_replay_file("Evening - Yunomi feat. nicamoq - Robotic Girl (Srav3R Remix) [Unscathed Heart] (2021-05-15) OsuMania.osr",
                      allow_unsupported_play_data=True)

data = a.play_data
```