### PR TITLE
skip initial frames with (x, y) == (256, -500)

### DIFF
--- a/osrparse/replay.py
+++ b/osrparse/replay.py
@@ -85,6 +85,10 @@ class _Unpacker:
             y = event[2]
             keys = int(event[3])
 
+            if time_delta == -12345 and i == len(events) - 1:
+                rng_seed = keys
+                continue
+
             # I don't really know why these frames exist, but lazer removes them
             # and they can cause issues for minigame replays - e.g., mania
             # interprets x as keys.
@@ -92,10 +96,6 @@ class _Unpacker:
             # https://github.com/ppy/osu/blob/6a04708a7e9801949c6c7ac7ddf6a4d7
             # fa0835e5/osu.Game/Scoring/Legacy/LegacyScoreDecoder.cs#L290-L294.
             if i < 2 and float(x) == 256 and float(y) == -500:
-                continue
-
-            if time_delta == -12345 and i == len(events) - 1:
-                rng_seed = keys
                 continue
 
             if mode is GameMode.STD:

--- a/osrparse/replay.py
+++ b/osrparse/replay.py
@@ -79,13 +79,22 @@ class _Unpacker:
 
         rng_seed = None
         play_data = []
-        for event in events:
+        for i, event in enumerate(events):
             time_delta = int(event[0])
             x = event[1]
             y = event[2]
             keys = int(event[3])
 
-            if time_delta == -12345 and event == events[-1]:
+            # I don't really know why these frames exist, but lazer removes them
+            # and they can cause issues for minigame replays - e.g., mania
+            # interprets x as keys.
+            # See
+            # https://github.com/ppy/osu/blob/6a04708a7e9801949c6c7ac7ddf6a4d7
+            # fa0835e5/osu.Game/Scoring/Legacy/LegacyScoreDecoder.cs#L290-L294.
+            if i < 2 and float(x) == 256 and float(y) == -500:
+                continue
+
+            if time_delta == -12345 and i == len(events) - 1:
                 rng_seed = keys
                 continue
 

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -65,7 +65,7 @@ class TestStandardReplay(TestCase):
     def test_play_data(self):
         for replay in self._replays:
             self.assertIsInstance(replay.replay_data[0], ReplayEventOsu, "Replay data is wrong")
-            self.assertEqual(len(replay.replay_data), 17500, "Replay data is wrong")
+            self.assertEqual(len(replay.replay_data), 17498, "Replay data is wrong")
 
     def test_replay_id(self):
         for replay in self._replays:
@@ -83,7 +83,7 @@ class TestTaikoReplay(TestCase):
     def test_play_data(self):
         replay_data = self.replay.replay_data
         self.assertIsInstance(replay_data[0], ReplayEventTaiko, "Replay data is wrong")
-        self.assertEqual(len(replay_data), 17475, "Replay data is wrong")
+        self.assertEqual(len(replay_data), 17473, "Replay data is wrong")
 
 class TestCatchReplay(TestCase):
 
@@ -94,7 +94,7 @@ class TestCatchReplay(TestCase):
     def test_play_data(self):
         replay_data = self.replay.replay_data
         self.assertIsInstance(replay_data[0], ReplayEventCatch, "Replay data is wrong")
-        self.assertEqual(len(replay_data), 10439, "Replay data is wrong")
+        self.assertEqual(len(replay_data), 10437, "Replay data is wrong")
 
 class TestManiaReplay(TestCase):
 
@@ -105,7 +105,7 @@ class TestManiaReplay(TestCase):
     def test_play_data(self):
         play_data = self.replay.replay_data
         self.assertIsInstance(play_data[0], ReplayEventMania, "Replay data is wrong")
-        self.assertEqual(len(play_data), 17432, "Replay data is wrong")
+        self.assertEqual(len(play_data), 17430, "Replay data is wrong")
 
 class TestLazerReplay(TestCase):
     @classmethod


### PR DESCRIPTION
see https://github.com/kszlim/osu-replay-parser/issues/39.

This is a breaking change and requires a major version bump.