### PR TITLE
Add property-based test for replay serialization

### DIFF
--- a/osrparse/strategies.py
+++ b/osrparse/strategies.py
@@ -1,0 +1,100 @@
+from datetime import timezone
+
+from hypothesis.strategies import (integers, text, booleans,
+    composite, from_type, lists, just, datetimes, floats)
+
+from osrparse import (Replay, GameMode, Mod, ReplayEventOsu, ReplayEventMania,
+    ReplayEventCatch, ReplayEventTaiko, KeyTaiko, KeyMania, Key)
+from osrparse.utils import LifeBarState
+
+def utf8():
+    return text("utf-8")
+
+def shorts():
+    return integers(0, 2 ** 16 - 1)
+
+def ints():
+    return integers(0, 2 ** 32 - 1)
+
+def longs():
+    return integers(0, 2 ** 64 - 1)
+
+def representable_float():
+    # lzma format only allows sane floats, ie no nan or inf.
+    return floats(allow_nan=False, allow_infinity=False)
+
+@composite
+def life_bar_states(draw):
+    return LifeBarState(
+        time=draw(integers()),
+        life=draw(representable_float())
+    )
+
+@composite
+def replay_events_osu(draw):
+    return ReplayEventOsu(
+        time_delta=draw(integers()),
+        x=draw(representable_float()),
+        y=draw(representable_float()),
+        keys=draw(from_type(Key))
+    )
+
+@composite
+def replay_events_taiko(draw):
+    return ReplayEventTaiko(
+        time_delta=draw(integers()),
+        x=draw(integers()),
+        keys=draw(from_type(KeyTaiko))
+    )
+
+@composite
+def replay_events_mania(draw):
+    return ReplayEventMania(
+        time_delta=draw(integers()),
+        keys=draw(from_type(KeyMania)),
+    )
+
+@composite
+def replay_events_catch(draw):
+    return ReplayEventCatch(
+        time_delta=draw(integers()),
+        x=draw(representable_float()),
+        dashing=draw(booleans())
+    )
+
+
+@composite
+def replays(draw):
+    mode = draw(from_type(GameMode))
+    replay_events = {
+        GameMode.STD: replay_events_osu,
+        GameMode.MANIA: replay_events_mania,
+        GameMode.CTB: replay_events_catch,
+        GameMode.TAIKO: replay_events_taiko
+    }[mode]
+
+    return Replay(
+        mode=mode,
+        game_version=draw(ints()),
+        beatmap_hash=draw(utf8()),
+        username=draw(utf8()),
+        replay_hash=draw(utf8()),
+        count_300=draw(shorts()),
+        count_100=draw(shorts()),
+        count_50=draw(shorts()),
+        count_geki=draw(shorts()),
+        count_katu=draw(shorts()),
+        count_miss=draw(shorts()),
+        score=draw(ints()),
+        max_combo=draw(shorts()),
+        perfect=draw(booleans()),
+        # TODO mod combinations
+        mods=draw(from_type(Mod)),
+        # TODO bug serializing empty life bar state, None vs []
+        life_bar_graph=draw(lists(life_bar_states(), min_size=1) | just(None)),
+        timestamp=draw(datetimes(timezones=just(timezone.utc))),
+        # TODO bug serializing empty replay_data. might be valid by osr spec?
+        replay_data=draw(lists(replay_events(), min_size=1)),
+        replay_id=draw(longs()),
+        rng_seed=draw(ints() | just(None))
+    )

--- a/osrparse/strategies.py
+++ b/osrparse/strategies.py
@@ -74,10 +74,10 @@ def replays(draw):
         perfect=draw(booleans()),
         # TODO mod combinations
         mods=draw(from_type(Mod)),
-        # TODO bug serializing empty life bar state, None vs []
+        # TODO issue with empty life bar state, None vs []
         life_bar_graph=draw(lists(life_bar_states, min_size=1) | just(None)),
         timestamp=draw(datetimes(timezones=just(timezone.utc))),
-        # TODO bug serializing empty replay_data. might be valid by osr spec?
+        # TODO issue with empty replay_data. might be valid by osr spec?
         replay_data=draw(lists(replay_events, min_size=1)),
         replay_id=draw(longs()),
         rng_seed=draw(ints() | just(None))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,5 +16,8 @@ classifiers = [
   "Programming Language :: Python :: 3"
 ]
 
+[project.optional-dependencies]
+dev = ["hypothesis"]
+
 [project.urls]
 "Homepage" = "https://github.com/kszlim/osu-replay-parser"

--- a/tests/test_dumping.py
+++ b/tests/test_dumping.py
@@ -1,29 +1,30 @@
 from pathlib import Path
-from unittest import TestCase
-from tempfile import TemporaryDirectory
+from datetime import timedelta
+
+from hypothesis import given
 
 from osrparse import Replay
+from osrparse.strategies import replays
 
 
 RES = Path(__file__).parent / "resources"
 
+@given(replays())
+def test_packing(replay: Replay):
+    packed = replay.pack()
+    replay2 = Replay.from_string(packed)
 
-class TestDumping(TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.replay = Replay.from_path(RES / "replay.osr")
-
-    def test_dumping(self):
-        packed = self.replay.pack()
-        r2 = Replay.from_string(packed)
-
-        # `replay_length` is intentionally not tested for equality here, as the
-        # length of the compressed replay data may change after dumping due to
-        # varying lzma settings.
-        attrs = ["mode", "game_version", "beatmap_hash", "username",
-            "replay_hash", "count_300", "count_100", "count_50", "count_geki",
-            "count_katu", "count_miss", "score", "max_combo", "perfect",
-            "mods", "life_bar_graph", "timestamp", "replay_data",
-            "replay_id"]
-        for attr in attrs:
-            self.assertEqual(getattr(self.replay, attr), getattr(r2, attr), attr)
+    # `replay_length` is intentionally not tested for equality here, as the
+    # length of the compressed replay data may change after dumping due to
+    # varying lzma settings.
+    attrs = ["mode", "game_version", "beatmap_hash", "username",
+        "replay_hash", "count_300", "count_100", "count_50", "count_geki",
+        "count_katu", "count_miss", "score", "max_combo", "perfect",
+        "mods", "life_bar_graph", "timestamp", "replay_data",
+        "replay_id"]
+    for attr in attrs:
+        if attr == "timestamp":
+            # TODO floating point issues :(
+            assert abs(replay.timestamp - replay2.timestamp) <= timedelta(milliseconds=1)
+            continue
+        assert getattr(replay, attr) == getattr(replay2, attr), attr

--- a/tests/test_dumping.py
+++ b/tests/test_dumping.py
@@ -17,14 +17,17 @@ def test_packing(replay: Replay):
     # `replay_length` is intentionally not tested for equality here, as the
     # length of the compressed replay data may change after dumping due to
     # varying lzma settings.
-    attrs = ["mode", "game_version", "beatmap_hash", "username",
+    attrs = [
+        "mode", "game_version", "beatmap_hash", "username",
         "replay_hash", "count_300", "count_100", "count_50", "count_geki",
         "count_katu", "count_miss", "score", "max_combo", "perfect",
         "mods", "life_bar_graph", "timestamp", "replay_data",
-        "replay_id"]
+        "replay_id"
+    ]
     for attr in attrs:
         if attr == "timestamp":
-            # TODO floating point issues :(
-            assert abs(replay.timestamp - replay2.timestamp) <= timedelta(milliseconds=1)
+            # TODO floating point issues, maybe? but probably going to be limited
+            # by precision of windows ticks compared to python microseconds.
+            assert abs(replay.timestamp - replay2.timestamp) < timedelta(microseconds=50)
             continue
         assert getattr(replay, attr) == getattr(replay2, attr), attr


### PR DESCRIPTION
I've had this branch sitting around for a while. I think it's worth adding hypothesis as an optional test dependency, and maybe expanding its use in our tests in the future.

I've put the strategy definition in the package proper, as libraries depending on osrparse may want to use it when defining their own strategies. As in, I may want to use osrparse's `replays` strategy in property based tests for [circlecore](https://github.com/circleguard/circlecore) in the future 😄