### PR TITLE
Update pack_long struct format from unsigned to signed long long

### DIFF
--- a/osrparse/replay.py
+++ b/osrparse/replay.py
@@ -193,7 +193,7 @@ class _Packer:
         return struct.pack("<I", data)
 
     def pack_long(self, data):
-        return struct.pack("<Q", data)
+        return struct.pack("<q", data)
 
     def pack_ULEB128(self, data):
         # https://github.com/mohanson/leb128

--- a/osrparse/replay.py
+++ b/osrparse/replay.py
@@ -29,7 +29,7 @@ class _Unpacker:
         return self.unpack_once("<I")
 
     def unpack_long(self):
-        return self.unpack_once("<Q")
+        return self.unpack_once("<q")
 
     def unpack_once(self, specifier):
         unpacked = struct.unpack_from(specifier, self.replay_data, self.offset)

--- a/osrparse/strategies.py
+++ b/osrparse/strategies.py
@@ -17,7 +17,7 @@ def ints():
     return integers(0, 2 ** 32 - 1)
 
 def longs():
-    r = 2**32 - 1
+    r = 2**63 - 1
     return integers(-r, r)
 
 def representable_floats():

--- a/osrparse/strategies.py
+++ b/osrparse/strategies.py
@@ -17,7 +17,8 @@ def ints():
     return integers(0, 2 ** 32 - 1)
 
 def longs():
-    return integers(0, 2 ** 64 - 1)
+    r = 2**32 - 1
+    return integers(-r, r)
 
 def representable_floats():
     # lzma format only allows sane floats, ie no nan or inf.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "osrparse"
-version = "7.0.0"
+version = "7.0.1"
 description = "Parser for osr files and lzma replay streams for osu!"
 readme = "README.md"
 keywords = ["osu!", "osr", "replay", "replays", "parsing", "parser", "python"]


### PR DESCRIPTION
This fixes writing some replays that originate from lazer.
By default in lazer replay.replay_id will be -1 (https://github.com/ppy/osu/blob/a6f56036a2c5df3f0427200ceb6fb8c321068ad6/osu.Game/Scoring/ScoreInfo.cs#L144), which will throw on save due to struct format used (unsigned long long) instead of long long.
