### PR TITLE
Fix not correct ULEB128 string length

### DIFF
--- a/osrparse/replay.py
+++ b/osrparse/replay.py
@@ -197,7 +197,7 @@ class _Packer:
 
     def pack_ULEB128(self, data):
         # https://github.com/mohanson/leb128
-        r, i = [], len(data)
+        r, i = [], len(data.encode("utf-8"))
 
         while True:
             byte = i & 0x7f

--- a/osrparse/replay.py
+++ b/osrparse/replay.py
@@ -197,7 +197,7 @@ class _Packer:
 
     def pack_ULEB128(self, data):
         # https://github.com/mohanson/leb128
-        r, i = [], len(data.encode("utf-8"))
+        r, i = [], len(data)
 
         while True:
             byte = i & 0x7f
@@ -211,8 +211,8 @@ class _Packer:
 
     def pack_string(self, data):
         if data:
-            return (self.pack_byte(11) + self.pack_ULEB128(data) +
-                data.encode("utf-8"))
+            data = data.encode("utf-8")
+            return self.pack_byte(11) + self.pack_ULEB128(data) + data
         return self.pack_byte(11) + self.pack_byte(0)
 
     def pack_timestamp(self):


### PR DESCRIPTION
When I tried modifying a username with UTF-8 characters, osu! cannot read this processed `.osr` file.  
After digging into it I found out the process of packing `String` does not work as intended. As what osu! wiki says `String` format should be `0x00` or `0x0b | [ULEB128, string length] | [string itself]`  , and the issue is caused by incorrect string length calculation.  
In python, one UTF-8 character's length is usually counted as 1 using `len()`, but in binary it is composed of 2 bytes, and osu! count one UTF-8 character's length as 2.  
This can be fixed by counting encoded string, and python will return its byte count. 